### PR TITLE
#1 feat: 파트장 투표 기능 구현

### DIFF
--- a/src/main/java/com/sharemindteam/votesystem/global/content/Part.java
+++ b/src/main/java/com/sharemindteam/votesystem/global/content/Part.java
@@ -1,6 +1,20 @@
 package com.sharemindteam.votesystem.global.content;
 
+import com.sharemindteam.votesystem.global.exception.PartNotFoundException;
+
+import java.util.Arrays;
+
 public enum Part {
     FRONTEND,
-    BACKEND
+    BACKEND;
+
+    public static Part getPartByName(String name) {
+        return Arrays.stream(Part.values())
+                .filter(part -> part.getName().equalsIgnoreCase(name))
+                .findAny().orElseThrow(() -> new PartNotFoundException(name));
+    }
+
+    private String getName() {
+        return this.name();
+    }
 }

--- a/src/main/java/com/sharemindteam/votesystem/global/exception/IllegalVoteException.java
+++ b/src/main/java/com/sharemindteam/votesystem/global/exception/IllegalVoteException.java
@@ -1,9 +1,14 @@
 package com.sharemindteam.votesystem.global.exception;
 
+import com.sharemindteam.votesystem.global.content.Part;
 import com.sharemindteam.votesystem.global.content.Team;
 
 public class IllegalVoteException extends RuntimeException {
     public IllegalVoteException(Team team) {
         super("본인의 소속팀 " + team.name() + "에는 투표할 수 없습니다.");
+    }
+
+    public IllegalVoteException(Part part) {
+        super("본인의 소속 파트가 아닌 " + part.name() + "에는 투표할 수 없습니다.");
     }
 }

--- a/src/main/java/com/sharemindteam/votesystem/global/exception/PartNotFoundException.java
+++ b/src/main/java/com/sharemindteam/votesystem/global/exception/PartNotFoundException.java
@@ -1,0 +1,7 @@
+package com.sharemindteam.votesystem.global.exception;
+
+public class PartNotFoundException extends RuntimeException {
+    public PartNotFoundException(String wrongPart) {
+        super("해당하는 파트가 존재하지 않습니다. : " + wrongPart);
+    }
+}

--- a/src/main/java/com/sharemindteam/votesystem/global/presentation/GlobalExceptionController.java
+++ b/src/main/java/com/sharemindteam/votesystem/global/presentation/GlobalExceptionController.java
@@ -3,6 +3,7 @@ package com.sharemindteam.votesystem.global.presentation;
 import com.sharemindteam.votesystem.global.exception.AlreadyVotedException;
 import com.sharemindteam.votesystem.global.exception.CandidateNotFoundException;
 import com.sharemindteam.votesystem.global.exception.IllegalVoteException;
+import com.sharemindteam.votesystem.global.exception.PartNotFoundException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -28,5 +29,11 @@ public class GlobalExceptionController {
     public ResponseEntity<String> catchIllegalVoteException(IllegalVoteException e) {
         log.error(e.getMessage(), e);
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+    }
+
+    @ExceptionHandler(PartNotFoundException.class)
+    public ResponseEntity<String> catchPartNotFoundException(PartNotFoundException e) {
+        log.error(e.getMessage(), e);
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
     }
 }

--- a/src/main/java/com/sharemindteam/votesystem/partLeader/application/PartLeaderService.java
+++ b/src/main/java/com/sharemindteam/votesystem/partLeader/application/PartLeaderService.java
@@ -1,0 +1,11 @@
+package com.sharemindteam.votesystem.partLeader.application;
+
+import com.sharemindteam.votesystem.global.content.Part;
+import com.sharemindteam.votesystem.partLeader.dto.response.PartLeaderResponse;
+
+import java.util.List;
+
+public interface PartLeaderService {
+    List<PartLeaderResponse> getPartLeaderCandidates(String part);
+    List<PartLeaderResponse> addPartLeaderVotes(Long userId, Long candidateId);
+}

--- a/src/main/java/com/sharemindteam/votesystem/partLeader/application/PartLeaderServiceImpl.java
+++ b/src/main/java/com/sharemindteam/votesystem/partLeader/application/PartLeaderServiceImpl.java
@@ -1,0 +1,64 @@
+package com.sharemindteam.votesystem.partLeader.application;
+
+import com.sharemindteam.votesystem.global.content.Part;
+import com.sharemindteam.votesystem.global.exception.AlreadyVotedException;
+import com.sharemindteam.votesystem.global.exception.CandidateNotFoundException;
+import com.sharemindteam.votesystem.global.exception.IllegalVoteException;
+import com.sharemindteam.votesystem.partLeader.domain.PartLeader;
+import com.sharemindteam.votesystem.partLeader.dto.response.PartLeaderResponse;
+import com.sharemindteam.votesystem.partLeader.repository.PartLeaderRepository;
+import com.sharemindteam.votesystem.user.domain.User;
+import com.sharemindteam.votesystem.user.exception.UserNotFoundException;
+import com.sharemindteam.votesystem.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class PartLeaderServiceImpl implements PartLeaderService {
+    private final PartLeaderRepository partLeaderRepository;
+    private final UserRepository userRepository;
+
+    @Override
+    public List<PartLeaderResponse> getPartLeaderCandidates(String partString) {
+
+        Part part = Part.getPartByName(partString);
+
+        return partLeaderRepository.findAllByPart(part, Sort.by(Sort.Direction.DESC, "votes"))
+                .stream()
+                .map(PartLeaderResponse::from)
+                .toList();
+    }
+
+    @Transactional
+    @Override
+    public List<PartLeaderResponse> addPartLeaderVotes(Long userId, Long candidateId) {
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException(userId));
+
+        if (user.isVotedPart()) {
+            throw new AlreadyVotedException();
+        }
+
+        PartLeader candidate = partLeaderRepository.findById(candidateId)
+                .orElseThrow(() -> new CandidateNotFoundException(candidateId));
+
+        if (!user.getPart().name().equals(candidate.getPart().name())) {
+            throw new IllegalVoteException(candidate.getPart());
+        }
+
+        candidate.increaseVotes();
+        user.updateVotedPartLeader();
+
+        return partLeaderRepository.findAllByPart(user.getPart(), Sort.by(Sort.Direction.DESC, "votes"))
+                .stream()
+                .map(PartLeaderResponse::from)
+                .toList();
+    }
+}

--- a/src/main/java/com/sharemindteam/votesystem/partLeader/domain/PartLeader.java
+++ b/src/main/java/com/sharemindteam/votesystem/partLeader/domain/PartLeader.java
@@ -2,6 +2,7 @@ package com.sharemindteam.votesystem.partLeader.domain;
 
 import com.sharemindteam.votesystem.global.common.BaseEntity;
 import com.sharemindteam.votesystem.global.content.Part;
+import com.sharemindteam.votesystem.global.content.Team;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -27,6 +28,9 @@ public class PartLeader extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     private Part part;
+
+    @Enumerated(EnumType.STRING)
+    private Team team;
     
     private Integer votes;
 

--- a/src/main/java/com/sharemindteam/votesystem/partLeader/domain/PartLeader.java
+++ b/src/main/java/com/sharemindteam/votesystem/partLeader/domain/PartLeader.java
@@ -29,4 +29,8 @@ public class PartLeader extends BaseEntity {
     private Part part;
     
     private Integer votes;
+
+    public void increaseVotes() {
+        votes++;
+    }
 }

--- a/src/main/java/com/sharemindteam/votesystem/partLeader/dto/response/PartLeaderResponse.java
+++ b/src/main/java/com/sharemindteam/votesystem/partLeader/dto/response/PartLeaderResponse.java
@@ -1,0 +1,27 @@
+package com.sharemindteam.votesystem.partLeader.dto.response;
+
+import com.sharemindteam.votesystem.partLeader.domain.PartLeader;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class PartLeaderResponse {
+    private final Long candidateId;
+    private final String name;
+    private final String team;
+
+    @Builder
+    public PartLeaderResponse(Long candidateId, String name, String team) {
+        this.candidateId = candidateId;
+        this.name = name;
+        this.team = team;
+    }
+
+    public static PartLeaderResponse from(PartLeader partLeader) {
+        return PartLeaderResponse.builder()
+                .candidateId(partLeader.getPartLeaderId())
+                .name(partLeader.getName())
+                .team(partLeader.getTeam().name())
+                .build();
+    }
+}

--- a/src/main/java/com/sharemindteam/votesystem/partLeader/presentation/PartLeaderController.java
+++ b/src/main/java/com/sharemindteam/votesystem/partLeader/presentation/PartLeaderController.java
@@ -1,0 +1,26 @@
+package com.sharemindteam.votesystem.partLeader.presentation;
+
+import com.sharemindteam.votesystem.partLeader.application.PartLeaderService;
+import com.sharemindteam.votesystem.partLeader.dto.response.PartLeaderResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/partLeader")
+@RequiredArgsConstructor
+public class PartLeaderController {
+    private final PartLeaderService partLeaderService;
+
+    @GetMapping
+    public ResponseEntity<List<PartLeaderResponse>> getPartLeaderCandidates(@RequestParam String part) {
+        return ResponseEntity.ok(partLeaderService.getPartLeaderCandidates(part));
+    }
+
+    @PatchMapping("/{candidateId}")
+    public ResponseEntity<List<PartLeaderResponse>> addPartLeaderVotes(@RequestParam Long userId, @PathVariable Long candidateId) {
+        return ResponseEntity.ok(partLeaderService.addPartLeaderVotes(userId, candidateId));
+    }
+}

--- a/src/main/java/com/sharemindteam/votesystem/partLeader/repository/PartLeaderRepository.java
+++ b/src/main/java/com/sharemindteam/votesystem/partLeader/repository/PartLeaderRepository.java
@@ -1,9 +1,14 @@
 package com.sharemindteam.votesystem.partLeader.repository;
 
+import com.sharemindteam.votesystem.global.content.Part;
 import com.sharemindteam.votesystem.partLeader.domain.PartLeader;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface PartLeaderRepository extends JpaRepository<PartLeader, Long> {
+    List<PartLeader> findAllByPart(Part part, Sort sort);
 }

--- a/src/main/java/com/sharemindteam/votesystem/partLeader/repository/PartLeaderRepository.java
+++ b/src/main/java/com/sharemindteam/votesystem/partLeader/repository/PartLeaderRepository.java
@@ -1,0 +1,9 @@
+package com.sharemindteam.votesystem.partLeader.repository;
+
+import com.sharemindteam.votesystem.partLeader.domain.PartLeader;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PartLeaderRepository extends JpaRepository<PartLeader, Long> {
+}

--- a/src/main/java/com/sharemindteam/votesystem/user/domain/User.java
+++ b/src/main/java/com/sharemindteam/votesystem/user/domain/User.java
@@ -48,4 +48,8 @@ public class User extends BaseEntity {
     public void updateVotedDemoday() {
         this.votedDemoday = true;
     }
+
+    public void updateVotedPartLeader() {
+        this.votedPart = true;
+    }
 }


### PR DESCRIPTION
## 📄구현 내용
- 파트장 후보 조회 api
- 파트장 투표 api

## 📝기타 알림사항
- 피그마에 맞춰 PartLeader 엔티티에 team 필드 추가
- 시큐리티 씌우고 나면 일부 수정 필요
  - api별 권한 처리
  - 데모데이 투표 api 요청 시 userId 처리 변경